### PR TITLE
Create AttributeDefaultBlockValue Cop

### DIFF
--- a/lib/rubocop/cop/infinum/attribute_default_block_value.rb
+++ b/lib/rubocop/cop/infinum/attribute_default_block_value.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+
+module RuboCop
+  module Cop
+    module Infinum
+      # This cop looks for `attribute` class methods that don't
+      # specify a `:default` option inside a block.
+      #
+      # @example
+      #   # bad
+      #   class User < ApplicationRecord
+      #     attribute :confirmed_at, :datetime, default: Time.zone.now
+      #   end
+      #
+      #   # good
+      #   class User < ActiveRecord::Base
+      #     attribute :confirmed_at, :datetime, default: -> { Time.zone.now }
+      #   end
+      class AttributeDefaultBlockValue < ::RuboCop::Cop::Cop
+        MSG = 'Pass a block to `:default` option.'
+
+        def_node_search :active_resource_class?, <<~PATTERN
+          (const (const nil? :ActiveResource) :Base)
+        PATTERN
+
+        def_node_matcher :attribute?, '(send nil? :attribute _ _ $hash)'
+
+        def on_send(node)
+          return if active_resource?(node.parent)
+
+          attribute?(node) do |third_arg|
+            default_attribute = default_attribute(third_arg)
+
+            unless [:block, :true, :false].include?(default_attribute.children.last.type) # rubocop:disable Lint/BooleanSymbol
+              add_offense(node, location: default_attribute)
+            end
+          end
+        end
+
+        private
+
+        def active_resource?(node)
+          return false if node.nil?
+
+          active_resource_class?(node)
+        end
+
+        def default_attribute(node)
+          node.children.first
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/infinum_cops.rb
+++ b/lib/rubocop/cop/infinum_cops.rb
@@ -1,1 +1,3 @@
 # frozen_string_literal: true
+
+require_relative 'infinum/attribute_default_block_value'

--- a/spec/rubocop/cop/infinum/attribute_default_block_value_spec.rb
+++ b/spec/rubocop/cop/infinum/attribute_default_block_value_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe(RuboCop::Cop::Infinum::AttributeDefaultBlockValue, :config) do
+  subject(:cop) { described_class.new(config) }
+
+  let(:message) { 'Pass a block to `:default` option.' }
+
+  describe('offenses') do
+    it('disallows symbol') do
+      expect_offense(<<~RUBY)
+        attribute :foo, :string, default: :bar
+                                 ^^^^^^^^^^^^^ #{message}
+      RUBY
+    end
+
+    it('disallows constant') do
+      expect_offense(<<~RUBY)
+        CONSTANT = :foo
+        attribute :bar, :string, default: CONSTANT
+                                 ^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+    end
+
+    it('disallows method') do
+      expect_offense(<<~RUBY)
+        attribute :foo, :string, default: bar
+                                 ^^^^^^^^^^^^ #{message}
+      RUBY
+    end
+
+    it('disallows method called from other class') do
+      expect_offense(<<~RUBY)
+        attribute :foo, :string, default: Time.zone.now
+                                 ^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+    end
+
+    it('allows boolean false') do
+      expect_no_offenses(<<~RUBY)
+        attribute :foo, :string, default: false
+      RUBY
+    end
+
+    it('allows boolean true') do
+      expect_no_offenses(<<~RUBY)
+        attribute :foo, :string, default: true
+      RUBY
+    end
+
+    it('allows block') do
+      expect_no_offenses(<<~RUBY)
+        attribute :foo, :string, default: -> { Time.zone.now }
+      RUBY
+    end
+
+    context 'when default option in new row' do
+      it('properly highlights violation') do
+        expect_offense(<<~RUBY)
+          attribute :foo,
+                    :string,
+                    default: :bar
+                    ^^^^^^^^^^^^^ #{message}
+        RUBY
+      end
+    end
+  end
+end


### PR DESCRIPTION
### TODO:
- just warn on node type `:send`? Meaning only method calls will be warned, not strings, symbols, numbers etc...