### PR TITLE
Exclude vendor/bundle/** for AllCops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,4 +42,5 @@ AllCops:
     - 'db/schema.rb'
     - 'db/migrate/*.rb'
     - 'config/**/*.rb'
+    - 'vendor/bundle/**/*'
   NewCops: enable


### PR DESCRIPTION
Now that we are running rubocop on Semaphore builds, we need to exclude vendor/bundle folder for AllCops. 

We were getting an error on build:

> vendor/bundle/ruby/2.7.0/bundler/gems/jsonapi_parameters-9e63c83ce492/.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
> Error: RuboCop found unsupported Ruby version 2.3 in `TargetRubyVersion` parameter (in vendor/bundle/ruby/2.7.0/bundler/gems/jsonapi_parameters-9e63c83ce492/.rubocop.yml). 2.3-compatible analysis was dropped after version 0.81.
> Supported versions: 2.5, 2.6, 2.7, 3.0, 3.1