### PR TITLE
Increase max line length to 120 chars and exclude comment lines

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,8 @@ require:
   - rubocop-rspec
 
 Layout/LineLength:
-  Max: 100
+  Max: 120
+  IgnoredPatterns: ['\A#']
 
 Metrics/BlockLength:
   Exclude:


### PR DESCRIPTION
Increased max chars to 120 as it's more or less a default value on our projects. Excluded comment lines from the rule, mainly to silence errors like these (when creating a new project, Rails creates comments which break the LineLength limit so Rubocop reports it as an offense):
<img width="824" alt="image" src="https://user-images.githubusercontent.com/36794420/125592702-81884744-2b0d-4f37-991f-3df137d0d8fc.png">
