### PR TITLE
Added rubocop-performance

### DIFF
--- a/rubocop-infinum.gemspec
+++ b/rubocop-infinum.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('rubocop')
   spec.add_runtime_dependency('rubocop-rails')
   spec.add_runtime_dependency('rubocop-rspec')
+  spec.add_runtime_dependency('rubocop-performance')
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-performance
 
 Layout/LineLength:
   Max: 120


### PR DESCRIPTION
I think it would be nice to include rubocop-performance cops to our rubocop config.

There's a bunch of useful stuff which we usually forget about:
https://github.com/rubocop/rubocop-performance/tree/master/lib/rubocop/cop/performance