### PR TITLE
Fix rubocop config file name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ And add to the top of your project's RuboCop configuration file:
 
   ~~~yml
   inherit_gem:
-    rubocop-infinum: .infinum.yml
+    rubocop-infinum: rubocop.yml
 
   require: rubocop-infinum
   ~~~


### PR DESCRIPTION
There was a leftover in readme from changing rubocop config name from `.infinum.yml` to `rubocop.yml`