### PR TITLE
Write cop for defining associations in factories

### DIFF
--- a/lib/rubocop/cop/infinum/factory_bot_association.rb
+++ b/lib/rubocop/cop/infinum/factory_bot_association.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+
+module RuboCop
+  module Cop
+    module Infinum
+      # This cop looks for 'association' in factories that specify a ':factory' option
+      # and tells you to use explicit build reference which improves the performance
+      # as cascading factories will not be saved unless needed to
+      #
+      # @example
+      #   #bad
+      #    FactoryBot.define do
+      #      factory :book do
+      #        title { 'Lord of the Rings' }
+      #        association :author
+      #      end
+      #    end
+      #
+      #    FactoryBoy.define do
+      #      factory :book do
+      #        title {'Lord of the Rings'}
+      #        author { association :author }
+      #      end
+      #    end
+      #
+      #    #good
+      #    FactoryBot.define do
+      #      factory :book do
+      #        title { 'Lord of the Rings' }
+      #        author { build(:author) }
+      #      end
+      #    end
+      #
+      #    FactoryBot.define do
+      #      factory :author do
+      #        name { 'J. R. R. Tolkien' }
+      #      end
+      #    end
+      class FactoryBotAssociation < ::RuboCop::Cop::Cop
+        MSG = 'Use %<association_name>s { build(:%<factory_name>s) } instead'
+
+        def_node_matcher :association_definition, <<~PATTERN
+          (send nil? :association (:sym $_) (hash (pair (sym :factory) (:sym $_))) ?)
+        PATTERN
+
+        def_node_matcher :inline_association_definition, <<~PATTERN
+          (block (send nil? $_) (args) (send nil? :association (sym $_)))
+        PATTERN
+
+        def on_block(node)
+          inline_association_definition(node) do |association_name, factory_name|
+            message = format(MSG, association_name: association_name.to_s, factory_name: factory_name.to_s)
+
+            add_offense(node, location: node, message: message)
+          end
+        end
+
+        def on_send(node)
+          return unless corrections.empty?
+
+          association_definition(node) do |association_name, factory_name|
+            factory_name = [association_name] if factory_name.empty?
+
+            message = format(MSG, association_name: association_name.to_s, factory_name: factory_name.first.to_s)
+
+            add_offense(node, location: node, message: message)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            if expression(node).size == 1
+              corrector.replace(node, "#{expression(node)[0]} { build(:#{expression(node)[0]}) }")
+            else
+              corrector.replace(node, "#{expression(node)[0]} { build(:#{expression(node)[1]}) }")
+            end
+          end
+        end
+
+        private
+
+        def expression(node)
+          @expression = if node.block_type?
+                          inline_association_definition(node)
+                        else
+                          association_definition(node).flatten
+                        end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/infinum_cops.rb
+++ b/lib/rubocop/cop/infinum_cops.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require_relative 'infinum/attribute_default_block_value'
+require_relative 'infinum/factory_bot_association'

--- a/spec/rubocop/cop/infinum/factory_bot_association_spec.rb
+++ b/spec/rubocop/cop/infinum/factory_bot_association_spec.rb
@@ -1,0 +1,107 @@
+RSpec.describe RuboCop::Cop::Infinum::FactoryBotAssociation, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+  let(:message) { "Use #{association_name} { build(:#{factory_name}) } instead" }
+
+  context 'when association name and factory name are the same' do
+    let(:association_name) { 'foo' }
+    let(:factory_name) { 'foo' }
+
+    it 'autocorrects method' do
+      expect_offense(<<~RUBY)
+        association :foo
+        ^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo { build(:foo) }
+      RUBY
+    end
+
+    it 'autocorrects inline method' do
+      expect_offense(<<~RUBY)
+        foo { association :foo }
+        ^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo { build(:foo) }
+      RUBY
+    end
+
+    it 'autocorrects method with explicit factory' do
+      expect_offense(<<~RUBY)
+        association :foo, factory: :foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo { build(:foo) }
+      RUBY
+    end
+
+    it 'autocorrects method in new line' do
+      expect_offense(<<~RUBY)
+        association :foo,
+        ^^^^^^^^^^^^^^^^^ #{message}
+                    factory: :foo
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo { build(:foo) }
+      RUBY
+    end
+
+    it 'allows using build' do
+      expect_no_offenses(<<~RUBY)
+        foo { build(:foo) }
+      RUBY
+    end
+  end
+
+  context 'when association name and factory name differ' do
+    let(:association_name) { 'foo' }
+    let(:factory_name) { 'bar' }
+
+    it 'autocorrects inline method' do
+      expect_offense(<<~RUBY)
+        foo { association :bar }
+        ^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo { build(:bar) }
+      RUBY
+    end
+
+    it 'autocorrects method with explicit factory' do
+      expect_offense(<<~RUBY)
+        association :foo, factory: :bar
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo { build(:bar) }
+      RUBY
+    end
+
+    it 'autocorrects method in new line' do
+      expect_offense(<<~RUBY)
+        association :foo,
+        ^^^^^^^^^^^^^^^^^ #{message}
+                    factory: :bar
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo { build(:bar) }
+      RUBY
+    end
+
+    it 'autocorrects using build' do
+      expect_no_offenses(<<~RUBY)
+        foo { build(:bar) }
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
## Issue [#14](https://github.com/infinum/rubocop-infinum/issues/14)

As per Jaka's [post](https://infinum.slack.com/archives/C027RRR17/p1620887579445300) on slack I have created a cop that will look for when we are using one of the three types of defining an association in a factory and suggest a correction.
I suggest looking at specs as there are the examples and what it will underline.

One problem that I simply did not know how to solve was when we have a situation of `foo { association :bar }` how to make it underline everything instead of just `association :bar`, usually it wouldn't pose a problem because the only problematic area is the `association :bar`, but the error message is set in a way that might make people not understand it correctly.

Could use your feedback on this, suggestions for test cases, error message and naming in general if need be.