### PR TITLE
Make attribute_default_block_value work even when no type is specified

### DIFF
--- a/lib/rubocop/cop/infinum/attribute_default_block_value.rb
+++ b/lib/rubocop/cop/infinum/attribute_default_block_value.rb
@@ -22,7 +22,7 @@ module RuboCop
         MSG = 'Pass method in a block to `:default` option.'
 
         def_node_matcher :default_attribute, <<~PATTERN
-          (send nil? :attribute _ _ (hash <$#attribute ...>))
+          (send nil? :attribute _ ?_ (hash <$#attribute ...>))
         PATTERN
 
         def_node_matcher :attribute, '(pair (sym :default) $_)'

--- a/spec/rubocop/cop/infinum/attribute_default_block_value_spec.rb
+++ b/spec/rubocop/cop/infinum/attribute_default_block_value_spec.rb
@@ -47,6 +47,13 @@ RSpec.describe(RuboCop::Cop::Infinum::AttributeDefaultBlockValue, :config) do
       RUBY
     end
 
+    it 'disallows when no type is specified' do
+      expect_offense(<<~RUBY)
+        attribute :foo, default: Foo.bar
+                                 ^^^^^^^ #{message}
+      RUBY
+    end
+
     it('allows boolean false') do
       expect_no_offenses(<<~RUBY)
         attribute :foo, :boolean, default: false
@@ -87,6 +94,12 @@ RSpec.describe(RuboCop::Cop::Infinum::AttributeDefaultBlockValue, :config) do
     it('allows block') do
       expect_no_offenses(<<~RUBY)
         attribute :foo, :datetime, default: -> { Time.zone.now }
+      RUBY
+    end
+
+    it 'allows block when no type is specified' do
+      expect_no_offenses(<<~RUBY)
+        attribute :foo, default: -> { Time.zone.now }
       RUBY
     end
 


### PR DESCRIPTION
Fixed the cop to work with optional type, added tests for good path and bad path aswell