### PR TITLE
Feature/change ignored warnings parameter

### DIFF
--- a/rubocop-infinum.gemspec
+++ b/rubocop-infinum.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('pry-byebug', '< 4')
   spec.add_development_dependency('rspec', '~> 3.9')
 
-  spec.add_runtime_dependency('rubocop')
+  spec.add_runtime_dependency('rubocop', '>= 1.28.0')
   spec.add_runtime_dependency('rubocop-rails')
   spec.add_runtime_dependency('rubocop-rspec')
   spec.add_runtime_dependency('rubocop-performance')

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -5,7 +5,7 @@ require:
 
 Layout/LineLength:
   Max: 120
-  IgnoredPatterns: ['\A#']
+  AllowedPatterns: ['\A#']
 
 Naming/InclusiveLanguage:
   Enabled: false


### PR DESCRIPTION
In version 1.28.0 rubocop has renamed IgnoredPatterns parameter to AllowedPatterns [changelog](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#changes)

It geenrates this kind of warning:
```
Warning: obsolete parameter `IgnoredPatterns` (for `Layout/LineLength`) found in /Users/kresimirvlahov/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-infinum-0.6.0/rubocop.yml
`IgnoredPatterns` has been renamed to `AllowedPatterns`.
```

Not sure if this justifies bumping the minor gem version, but I figured it did since this only affects rubocop >= 1.28.0