### PR TITLE
Update FactoryBotAssociation cop to fix deprecation warnings

### DIFF
--- a/lib/rubocop/cop/infinum/factory_bot_association.rb
+++ b/lib/rubocop/cop/infinum/factory_bot_association.rb
@@ -53,19 +53,17 @@ module RuboCop
           inline_association_definition(node) do |association_name, factory_name|
             message = format(MSG, association_name: association_name.to_s, factory_name: factory_name.to_s)
 
-            add_offense(node, location: node, message: message)
+            add_offense(node, message: message)
           end
         end
 
         def on_send(node)
-          return unless corrections.empty?
-
           association_definition(node) do |association_name, factory_name|
             factory_name = [association_name] if factory_name.empty?
 
             message = format(MSG, association_name: association_name.to_s, factory_name: factory_name.first.to_s)
 
-            add_offense(node, location: node, message: message)
+            add_offense(node, message: message)
           end
         end
 
@@ -82,11 +80,11 @@ module RuboCop
         private
 
         def expression(node)
-          @expression = if node.block_type?
-                          inline_association_definition(node)
-                        else
-                          association_definition(node).flatten
-                        end
+          if node.block_type?
+            inline_association_definition(node)
+          else
+            association_definition(node).flatten
+          end
         end
       end
     end

--- a/spec/rubocop/cop/infinum/factory_bot_association_spec.rb
+++ b/spec/rubocop/cop/infinum/factory_bot_association_spec.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::Infinum::FactoryBotAssociation, :config do
   subject(:cop) { described_class.new(config) }
 
   let(:config) { RuboCop::Config.new }
-  let(:message) { "Use #{association_name} { build(:#{factory_name}) } instead" }
 
   context 'when association name and factory name are the same' do
     let(:association_name) { 'foo' }
@@ -11,7 +12,7 @@ RSpec.describe RuboCop::Cop::Infinum::FactoryBotAssociation, :config do
     it 'autocorrects method' do
       expect_offense(<<~RUBY)
         association :foo
-        ^^^^^^^^^^^^^^^^ #{message}
+        ^^^^^^^^^^^^^^^^ #{message(association_name, factory_name)}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -22,7 +23,8 @@ RSpec.describe RuboCop::Cop::Infinum::FactoryBotAssociation, :config do
     it 'autocorrects inline method' do
       expect_offense(<<~RUBY)
         foo { association :foo }
-        ^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+              ^^^^^^^^^^^^^^^^ #{message(association_name, factory_name)}
+        ^^^^^^^^^^^^^^^^^^^^^^^^ #{message(association_name, factory_name)}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -33,7 +35,7 @@ RSpec.describe RuboCop::Cop::Infinum::FactoryBotAssociation, :config do
     it 'autocorrects method with explicit factory' do
       expect_offense(<<~RUBY)
         association :foo, factory: :foo
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message(association_name, factory_name)}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -44,7 +46,7 @@ RSpec.describe RuboCop::Cop::Infinum::FactoryBotAssociation, :config do
     it 'autocorrects method in new line' do
       expect_offense(<<~RUBY)
         association :foo,
-        ^^^^^^^^^^^^^^^^^ #{message}
+        ^^^^^^^^^^^^^^^^^ #{message(association_name, factory_name)}
                     factory: :foo
       RUBY
 
@@ -64,21 +66,10 @@ RSpec.describe RuboCop::Cop::Infinum::FactoryBotAssociation, :config do
     let(:association_name) { 'foo' }
     let(:factory_name) { 'bar' }
 
-    it 'autocorrects inline method' do
-      expect_offense(<<~RUBY)
-        foo { association :bar }
-        ^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-      RUBY
-
-      expect_correction(<<~RUBY)
-        foo { build(:bar) }
-      RUBY
-    end
-
     it 'autocorrects method with explicit factory' do
       expect_offense(<<~RUBY)
         association :foo, factory: :bar
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message(association_name, factory_name)}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -89,7 +80,7 @@ RSpec.describe RuboCop::Cop::Infinum::FactoryBotAssociation, :config do
     it 'autocorrects method in new line' do
       expect_offense(<<~RUBY)
         association :foo,
-        ^^^^^^^^^^^^^^^^^ #{message}
+        ^^^^^^^^^^^^^^^^^ #{message(association_name, factory_name)}
                     factory: :bar
       RUBY
 
@@ -103,5 +94,9 @@ RSpec.describe RuboCop::Cop::Infinum::FactoryBotAssociation, :config do
         foo { build(:bar) }
       RUBY
     end
+  end
+
+  def message(association_name, factory_name)
+    "Infinum/FactoryBotAssociation: Use #{association_name} { build(:#{factory_name}) } instead"
   end
 end


### PR DESCRIPTION
Newer versions of rubocop raise warning: `Cop#corrections` is deprecated.
`.../vendor/bundle/ruby/3.2.0/gems/rubocop-infinum-0.8.0/lib/rubocop/cop/infinum/factory_bot_association.rb:61: warning: Cop#corrections is deprecated.`
Deprecation warning was added in [cop.rb](https://github.com/rubocop/rubocop/blob/master/lib/rubocop/cop/cop.rb#L98-L100) of [this commit](https://github.com/rubocop/rubocop/commit/2d332e9fccfd638ed1322e0cfc4e2db08c3aee81) in July 2024

In related projects we may have hundreds of such warnings and want to get rid of it.

Existing occurrences of this `corrections` method may be removed/rewritten and new version of gem can be released.

```
FactoryBot.define do
  factory :author do
    association :book
  end
end
```
Detection:
```
spec/factories/authors.rb:5:5: C: [Correctable] Infinum/FactoryBotAssociation: Use book { build(:book) } instead
    association :book
    ^^^^^^^^^^^^^^^^^
```
Autocorrection:
```
 spec/factories/authors.rb -A
Offenses:

spec/factories/authors.rb:5:5: C: [Corrected] Infinum/FactoryBotAssociation: Use book { build(:book) } instead
    association :book
    ^^^^^^^^^^^^^^^^^
---
FactoryBot.define do
  factory :author do
    book { build(:book) }
  end
end
```