### PR TITLE
[UPGRADE] New rubocop gems and resolved deprecations

### DIFF
--- a/rubocop-infinum.gemspec
+++ b/rubocop-infinum.gemspec
@@ -31,7 +31,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rspec', '~> 3.9')
 
   spec.add_runtime_dependency('rubocop', '>= 1.28.0')
+  spec.add_runtime_dependency('rubocop-factory_bot')
+  spec.add_runtime_dependency('rubocop-performance')
   spec.add_runtime_dependency('rubocop-rails')
   spec.add_runtime_dependency('rubocop-rspec')
-  spec.add_runtime_dependency('rubocop-performance')
+  spec.add_runtime_dependency('rubocop-rspec_rails')
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,6 +1,8 @@
 require:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-rspec_rails
+  - rubocop-factory_bot
   - rubocop-performance
 
 Layout/LineLength:

--- a/spec/rubocop/cop/infinum/attribute_default_block_value_spec.rb
+++ b/spec/rubocop/cop/infinum/attribute_default_block_value_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe(RuboCop::Cop::Infinum::AttributeDefaultBlockValue, :config) do
   subject(:cop) { described_class.new(config) }
 
   let(:config) { RuboCop::Config.new }
-  let(:message) { 'Pass method in a block to `:default` option.' }
+  let(:message) { 'Infinum/AttributeDefaultBlockValue: Pass method in a block to `:default` option.' }
 
   context 'when `:default` option is last' do
     it('disallows method') do


### PR DESCRIPTION
#### Problem

Rubocop has separated gems for FactoryBot and Rspec/Rails cops:

* [rubocop-factory_bot](https://github.com/rubocop/rubocop-factory_bot)
* [rubocop-rspec_rails](https://github.com/rubocop/rubocop-rspec_rails)

Also, the current version of the gem uses the old Rubocop API, and it raises a deprecation warning:

```
lib/rubocop/cop/infinum/factory_bot_association.rb:41: 
warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
```

#### Solution

* added new gems as a part of the `rubocop-infinum` gem
* updated cops to use new API