### PR TITLE
Pluginify Rubocop Infinum

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ To use it, you can add this to your `Gemfile` (`group :development`):
 And add to the top of your project's RuboCop configuration file:
 
   ~~~yml
-  inherit_gem:
-    rubocop-infinum: rubocop.yml
-
-  require: rubocop-infinum
+  plugins: rubocop-infinum
   ~~~
+
+
+> [!NOTE]
+> The plugin system is supported in RuboCop 1.72+. In earlier versions, use `require` instead of `plugins`.
 
 If you dislike some rules, please check [RuboCop's documentation](https://rubocop.readthedocs.io/en/latest/configuration/#inheriting-configuration-from-a-dependency-gem) on inheriting configuration from a gem.

--- a/lib/rubocop-infinum.rb
+++ b/lib/rubocop-infinum.rb
@@ -6,6 +6,7 @@ require 'rubocop'
 
 require_relative 'rubocop/infinum'
 require_relative 'rubocop/infinum/version'
+require_relative 'rubocop/infinum/plugin'
 
 require_relative 'rubocop/cop/infinum_cops'
 

--- a/lib/rubocop/infinum/plugin.rb
+++ b/lib/rubocop/infinum/plugin.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rubocop/infinum/version'
+require 'lint_roller'
+
+module RuboCop
+  module Infinum
+    # The main plugin class for RuboCop Infinum.
+    class Plugin < LintRoller::Plugin
+      def about
+        LintRoller::About.new(
+          name: 'rubocop-infinum',
+          version: VERSION,
+          homepage: 'https://github.com/infinum/rubocop-infinum',
+          description: 'This plugin provides the RuboCop configuration file ' \
+                       'alongside some custom cops used at Infinum.'
+        )
+      end
+
+      def supported?(context)
+        context.engine == :rubocop
+      end
+
+      def rules(_context)
+        LintRoller::Rules.new(
+          type: :path,
+          config_format: :rubocop,
+          value: Pathname.new(__dir__).join('../../../rubocop.yml')
+        )
+      end
+    end
+  end
+end

--- a/rubocop-infinum.gemspec
+++ b/rubocop-infinum.gemspec
@@ -31,11 +31,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('pry-byebug', '< 4')
   spec.add_development_dependency('rspec', '~> 3.9')
 
-  spec.add_dependency('lint_roller', '~> 1.1')
-  spec.add_dependency('rubocop', '>= 1.72.1', '< 2.0')
-  spec.add_runtime_dependency('rubocop-factory_bot', '>=2.27.1', '< 3.0')
-  spec.add_runtime_dependency('rubocop-performance', '>= 1.24.0', '< 2.0')
-  spec.add_runtime_dependency('rubocop-rails', '>= 2.30.0', '< 3.0')
-  spec.add_runtime_dependency('rubocop-rspec', '>= 3.5.0', '< 4.0')
-  spec.add_runtime_dependency('rubocop-rspec_rails', '>= 2.31.0', '< 3.0')
+  spec.add_dependency('lint_roller')
+  spec.add_dependency('rubocop', '>= 1.72.1')
+  spec.add_runtime_dependency('rubocop-factory_bot', '>=2.27.1')
+  spec.add_runtime_dependency('rubocop-performance', '>= 1.24.0')
+  spec.add_runtime_dependency('rubocop-rails', '>= 2.30.0')
+  spec.add_runtime_dependency('rubocop-rspec', '>= 3.5.0')
+  spec.add_runtime_dependency('rubocop-rspec_rails', '>= 2.31.0')
 end

--- a/rubocop-infinum.gemspec
+++ b/rubocop-infinum.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/infinum/rubocop-infinum'
+  spec.metadata['default_lint_roller_plugin'] = 'RuboCop::Infinum::Plugin'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -30,10 +31,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('pry-byebug', '< 4')
   spec.add_development_dependency('rspec', '~> 3.9')
 
-  spec.add_runtime_dependency('rubocop', '>= 1.28.0')
-  spec.add_runtime_dependency('rubocop-factory_bot')
-  spec.add_runtime_dependency('rubocop-performance')
-  spec.add_runtime_dependency('rubocop-rails')
-  spec.add_runtime_dependency('rubocop-rspec')
-  spec.add_runtime_dependency('rubocop-rspec_rails')
+  spec.add_dependency('lint_roller', '~> 1.1')
+  spec.add_dependency('rubocop', '>= 1.72.1', '< 2.0')
+  spec.add_runtime_dependency('rubocop-factory_bot', '>=2.27.1', '< 3.0')
+  spec.add_runtime_dependency('rubocop-performance', '>= 1.24.0', '< 2.0')
+  spec.add_runtime_dependency('rubocop-rails', '>= 2.30.0', '< 3.0')
+  spec.add_runtime_dependency('rubocop-rspec', '>= 3.5.0', '< 4.0')
+  spec.add_runtime_dependency('rubocop-rspec_rails', '>= 2.31.0', '< 3.0')
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-rspec_rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,6 @@ require 'rubocop/rspec/support'
 require 'pry-byebug'
 
 RSpec.configure do |config|
-  config.include(RuboCop::RSpec::ExpectOffense)
-
   config.disable_monkey_patching!
   config.raise_errors_for_deprecations!
 


### PR DESCRIPTION
**Problem:**
RuboCop's Plugin feature was introduced in RuboCop 1.72  to provide officially documented ways to extend RuboCop.
See [the Rubocop doc](https://docs.rubocop.org/rubocop/extensions.html) for more details.

**Solution:**

- Pluginify Rubocop Infinum
- update rubocop dependencies
- Use plugins in the rubocop.yml
